### PR TITLE
🎈 fix countdown slot Bug

### DIFF
--- a/components/statistic/Countdown.tsx
+++ b/components/statistic/Countdown.tsx
@@ -16,7 +16,7 @@ export default defineComponent({
     format: 'HH:mm:ss',
   }),
   emits: ['finish', 'change'],
-  setup(props, { emit }) {
+  setup(props, { emit, slots }) {
     const countdownId = ref<any>();
     const statistic = ref();
     const syncTimer = () => {
@@ -76,6 +76,9 @@ export default defineComponent({
       stopTimer();
     });
     return () => {
+      const title = props.title ?? slots.title?.();
+      const prefix = props.prefix ?? slots.prefix?.();
+      const suffix = props.suffix ?? slots.suffix?.();
       return (
         <Statistic
           ref={statistic}
@@ -83,6 +86,11 @@ export default defineComponent({
             ...props,
             valueRender: valueRenderHtml,
             formatter: formatCountdown,
+          }}
+          v-slots={{
+            title,
+            prefix,
+            suffix,
           }}
         />
       );

--- a/components/statistic/demo/countdown-slot.vue
+++ b/components/statistic/demo/countdown-slot.vue
@@ -1,0 +1,68 @@
+<docs>
+---
+order: 4
+title:
+  zh-CN: 倒计时组件
+  en-US: Countdown
+---
+
+## zh-CN
+
+倒计时组件使用插槽。
+
+## en-US
+
+Countdown component slots.
+
+</docs>
+
+<template>
+  <a-row :gutter="16">
+    <a-col :span="12">
+      <a-statistic-countdown :value="deadline" style="margin-right: 50px" @finish="onFinish">
+        <template #title>
+          <span>Countdown</span>
+          <a-tooltip placement="right">
+            <template #title>
+              <span>hurry up!</span>
+            </template>
+            <question-circle-two-tone style="margin-left: 5px" />
+          </a-tooltip>
+        </template>
+      </a-statistic-countdown>
+    </a-col>
+    <a-col :span="24" style="margin-top: 32px">
+      <a-statistic-countdown
+        title="Million Seconds countdown"
+        :value="deadline"
+        format="HH:mm:ss:SSS"
+        style="margin-right: 50px"
+      >
+        <template #prefix>
+          <span>There's only</span>
+        </template>
+        <template #suffix>
+          <span>left for the end.</span>
+        </template>
+      </a-statistic-countdown>
+    </a-col>
+  </a-row>
+</template>
+<script lang="ts">
+import { QuestionCircleTwoTone } from '@ant-design/icons-vue';
+import { defineComponent } from 'vue';
+export default defineComponent({
+  components: {
+    QuestionCircleTwoTone,
+  },
+  setup() {
+    const onFinish = () => {
+      console.log('finished!');
+    };
+    return {
+      deadline: Date.now() + 1000 * 60 * 60 * 20 * 2,
+      onFinish,
+    };
+  },
+});
+</script>

--- a/components/statistic/demo/index.vue
+++ b/components/statistic/demo/index.vue
@@ -4,6 +4,7 @@
     <unit />
     <card />
     <countdown />
+    <countdown-slot />
   </demo-sort>
 </template>
 <script lang="ts">
@@ -11,6 +12,7 @@ import Basic from './basic.vue';
 import Unit from './unit.vue';
 import Card from './card.vue';
 import Countdown from './countdown.vue';
+import CountdownSlot from './countdown-slot.vue';
 import CN from '../index.zh-CN.md';
 import US from '../index.en-US.md';
 import { defineComponent } from 'vue';
@@ -22,6 +24,7 @@ export default defineComponent({
     Unit,
     Card,
     Countdown,
+    CountdownSlot,
   },
   setup() {
     return {};


### PR DESCRIPTION
Fix <a-statistic-countdown> can't slot Bug

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> In the documentation on the official website, I found that the countdown component can slot title、suffix and prefix.But in my practice, this feature doesn't work correctly
>
> In this case, the problem of recurrence [[Vue Antd Template (forked) - CodeSandbox](https://codesandbox.io/s/vue-antd-template-forked-g41wx?file=/src/App.vue)].
>
> I tried to fix that, and that's why the PR came in.

### Self Check before Merge

- [x] Doc is updated/provided 
- [x] Demo is updated/provided 

